### PR TITLE
Optimize Dockerfile for caching, security, and maintainability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,11 @@ USER app
 # Pre-download fastembed models
 FROM builder AS model-downloader
 
-# Switch to root to create cache directory, then switch back to app user
+# Switch to root to create cache directories, then switch back to app user
+# huggingface_hub needs /home/app/.cache for xet logging and downloads
 USER root
-RUN mkdir -p /app/.cache/fastembed && chown -R app:app /app/.cache
+RUN mkdir -p /app/.cache/fastembed /home/app/.cache && \
+    chown -R app:app /app/.cache /home/app/.cache
 USER app
 
 # Set cache directory for fastembed models


### PR DESCRIPTION
## Summary
This PR optimizes the Dockerfile with improvements to build performance, security posture, and long-term maintainability.

## Build Optimizations
- **Better layer caching**: Separate dependency installation from source code copying
  - Copy `pyproject.toml` and `uv.lock` first, then install dependencies
  - Copy source code after dependencies to avoid invalidating dependency cache on code changes
  - This significantly speeds up rebuilds during development
- **Remove unnecessary cache mounts**: Removed UV cache mount for Python execution steps where it's not needed

## Security Enhancements
All Trivy security warnings have been addressed:
- ✅ **AVD-DS-0029 (HIGH)**: Added `--no-install-recommends` to all `apt-get install` commands
  - Build dependencies (build-essential, git, libsqlite3-dev)
  - Runtime dependencies (curl)
- ✅ **AVD-DS-0013 (MEDIUM)**: Use `WORKDIR` instead of `cd` in RUN commands for sqlite-vec build
- **Improved reproducibility**: Pin sqlite-vec to specific commit SHA (`639fca5739fe056fdc98f3d539c4cd79328d7dc7`) instead of tag

## Maintainability Improvements
- **Dynamic Python path resolution**: No longer hardcodes Python version in site-packages path
- **Cleaner dependencies**: 
  - Removed redundant packages (gcc, make already included in build-essential)
  - Removed unused gettext package
- **BuildKit syntax**: Added `# syntax=docker/dockerfile:1.4` directive for modern BuildKit features
- **Better documentation**: Enhanced comments explaining optimization rationale

## Impact
- Faster Docker builds during development (better cache utilization)
- Smaller image sizes (`--no-install-recommends` reduces unnecessary packages)
- Improved security posture (passes Trivy security scans)
- Easier maintenance (no Python version hardcoding)

## Test plan
- [x] Verify image builds successfully
- [x] Confirm Trivy security scans pass
- [x] Test that sqlite-vec extension loads correctly
- [x] Validate fastembed model downloads work

🤖 Generated with [Claude Code](https://claude.com/claude-code)