### PR TITLE
Fix Docker package installation issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
 COPY --chown=app:app README.md ./
 COPY --chown=app:app src/ ./src/
 
+# Reinstall the package now that source code is present
+RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
+    uv sync --package toolhive-doc-mcp --no-dev --locked --no-editable
+
 # Copy pre-built sqlite-vec extension using dynamic path resolution
 # This avoids hardcoding Python version in the path
 COPY --from=sqlite-vec-builder /sqlite-vec-dist/vec0.so /tmp/vec0.so


### PR DESCRIPTION
## Problem

The Docker container fails on startup with:
```
ModuleNotFoundError: No module named 'src'
```

## Root Cause

The Dockerfile was:
1. Running `uv sync` to install dependencies and the package
2. **Then** copying the source code
3. But never reinstalling the package after the source was available

This meant the entry point script `/app/.venv/bin/toolhive-doc-mcp` was created, but it couldn't import `from src.mcp_server` because the package wasn't actually installed with the source files.

## Solution

Added a second `uv sync` command **after** copying the source code:

```dockerfile
# Copy source code after dependencies (doesn't invalidate dependency cache)
COPY --chown=app:app README.md ./
COPY --chown=app:app src/ ./src/

# Reinstall the package now that source code is present
RUN --mount=type=cache,target=/home/app/.cache/uv,uid=1000,gid=1000 \
    uv sync --package toolhive-doc-mcp --no-dev --locked --no-editable
```

This approach:
- ✅ Preserves dependency layer caching (first sync installs deps)
- ✅ Ensures the package is properly installed with source code (second sync)
- ✅ The second sync is fast since dependencies are already installed
- ✅ Only invalidates the cache when source code changes, not when dependencies change

## Testing

- Verified the package builds correctly locally with `uv build`
- Confirmed wheel contains all source files in `src/` directory
- Entry point script will now be able to import the module

## Files Changed

- `Dockerfile` - Added reinstall step after copying source code (4 lines added)