### PR TITLE
Add trigger to update infra repo when new image is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,13 @@ jobs:
           fi
 
       - name: Trigger infra image update
-        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: success()
+        continue-on-error: true
         env:
           INFRA_REPO: stacklok/infra
           IMAGE_NAME: ghcr.io/${{ steps.repo_owner.outputs.OWNER }}/toolhive-doc-mcp
           IMAGE_TAG: ${{ github.ref_name }}  # e.g., v0.0.6
+          GH_TOKEN: ${{ secrets.INFRA_DISPATCH_TOKEN }}
         run: |
           gh api repos/$INFRA_REPO/dispatches \
             -X POST \


### PR DESCRIPTION
## Summary

This PR adds a step to the release workflow that automatically triggers the infra repository's MCP Server image update workflow when a new image tag is pushed.

## Changes

- Added a new step `Trigger infra image update` to the release workflow
- Triggers on successful tag pushes (v* tags)
- Sends `repository_dispatch` event to `stacklok/infra` with image information
- Enables automatic image version updates in ArgoCD MCPServer resources

## How It Works

1. When a new tag is pushed (e.g., `v0.0.6`), the release workflow builds and publishes the image
2. After successful image signing, this new step triggers the infra repo workflow
3. The infra workflow automatically finds and updates MCPServer resources using the new image
4. A PR is created in the infra repo with the updated image versions
5. Once merged, ArgoCD automatically syncs the new image versions

## Integration

This works in conjunction with the workflow added in stacklok/infra#3682, which handles the actual image updates in ArgoCD configurations.

## Testing

- The trigger only runs on successful tag pushes
- Uses the dynamic repository owner (works with stackloklabs or other orgs)
- Includes both image name and tag in the payload for proper identification