### PR TITLE
Add CLI command for Kubernetes cronjob refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ toolhive-doc-mcp = { workspace = true }
 
 [project.scripts]
 toolhive-doc-mcp = "src.mcp_server:main"
+toolhive-refresh = "src.refresh:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -193,7 +193,7 @@ def _startup_sync() -> None:
             logger.info("Initializing background refresh orchestrator")
             _scheduler = BackgroundScheduler()
 
-            _refresh_orchestrator = RefreshOrchestrator(enabled=refresh_config.enabled)
+            _refresh_orchestrator = RefreshOrchestrator()
             _refresh_orchestrator.configure_scheduler_sync(
                 scheduler=_scheduler,
                 interval_hours=refresh_config.interval_hours,

--- a/src/refresh.py
+++ b/src/refresh.py
@@ -1,0 +1,69 @@
+"""CLI command for executing refresh operations"""
+
+import logging
+import sys
+from datetime import datetime
+
+from src.services.refresh_orchestrator import RefreshOrchestrator
+from src.utils.sources_loader import load_sources_config
+
+
+def setup_logging() -> None:
+    """Configure logging for CLI (stdout for K8s)"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+def main() -> int:
+    """
+    Main entry point for refresh CLI command
+
+    Returns:
+        int: Exit code (0 for success, 1 for failure)
+    """
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
+    try:
+        logger.info("Starting refresh operation")
+        logger.info(f"Timestamp: {datetime.now().isoformat()}")
+
+        # Load configuration
+        sources_config = load_sources_config()
+        refresh_config = sources_config.refresh
+        logger.info(f"Loaded config: interval={refresh_config.interval_hours}h")
+
+        # Check if enabled (warn but don't fail)
+        if not refresh_config.enabled:
+            logger.warning("Refresh is disabled in configuration")
+            logger.info("Exiting with success (NoOp due to disabled config)")
+            return 0
+
+        # Initialize and execute
+        logger.info("Initializing RefreshOrchestrator")
+        orchestrator = RefreshOrchestrator()
+
+        logger.info("Executing refresh_once()")
+        result = orchestrator.refresh_once()
+
+        # Log results
+        if result.success:
+            logger.info(f"Refresh completed successfully in {result.duration_seconds:.2f}s")
+            return 0
+        else:
+            logger.error(f"Refresh failed: {result.error}")
+            return 1
+
+    except FileNotFoundError as e:
+        logger.error(f"Configuration file not found: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Related to: https://github.com/StacklokLabs/toolhive-doc-mcp/issues/13

Adds standalone CLI command for executing refresh operations from Kubernetes cronjobs.

## Changes

- Added `toolhive-refresh` CLI command that can be invoked from K8s cronjobs
- New `src/refresh.py` with main() entry point for standalone execution
- Proper exit codes (0 = success, 1 = failure) for cronjob monitoring
- Structured logging to stdout (Kubernetes compatible)
- Reuses existing RefreshOrchestrator NoOp logic
- Fixed bug in RefreshOrchestrator initialization

## Usage

**Locally:**
```bash
uv run toolhive-refresh
```

**In Kubernetes:**
Use the same container image as the MCP server, override the command:
```yaml
apiVersion: batch/v1
kind: CronJob
spec:
  schedule: "0 */6 * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: refresh
            image: toolhive-doc-mcp:latest
            command: ["toolhive-refresh"]
```

No separate Docker image needed - the command runs in the same container with a different entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)