### PR TITLE
ci: separate semver releases from weekly content rebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,17 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             # Tag-push event: extract version from GITHUB_REF
             VERSION="${GITHUB_REF#refs/tags/v}"
-            echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-            echo "WEEKLY_TAG=" >> $GITHUB_OUTPUT
-            echo "IS_WEEKLY=false" >> $GITHUB_OUTPUT
           else
             # Schedule or workflow_dispatch: content rebuild on latest semver
             LATEST_TAG=$(git tag -l 'v*' | grep -v '-' | sort -V | tail -n 1)
             echo "Latest base version tag: ${LATEST_TAG}"
             VERSION="${LATEST_TAG#v}"
-
-            WEEKLY_TAG="v${VERSION}-$(date -u +%Y%m%d)"
-            echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-            echo "WEEKLY_TAG=${WEEKLY_TAG}" >> $GITHUB_OUTPUT
-            echo "IS_WEEKLY=true" >> $GITHUB_OUTPUT
           fi
+
+          WEEKLY_TAG="v${VERSION}-$(date -u +%Y%m%d)"
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "WEEKLY_TAG=${WEEKLY_TAG}" >> $GITHUB_OUTPUT
+          echo "IS_WEEKLY=${{ github.event_name != 'push' }}" >> $GITHUB_OUTPUT
 
   code_checks:
     name: Code Checks
@@ -102,15 +99,14 @@ jobs:
           IS_WEEKLY="${{ steps.tag.outputs.IS_WEEKLY }}"
           WEEKLY_TAG="${{ steps.tag.outputs.WEEKLY_TAG }}"
 
+          # Always include latest and date-stamped tag
+          TAGS="${IMAGE}:latest"
+          TAGS="${TAGS},${IMAGE}:${WEEKLY_TAG}"
+
           if [[ "${IS_WEEKLY}" == "false" ]]; then
-            # Tag-push: new semver release
-            TAGS="${IMAGE}:latest"
+            # Tag-push: also publish semver tags
             TAGS="${TAGS},${IMAGE}:v${VERSION}"
             TAGS="${TAGS},${IMAGE}:${VERSION}"
-          else
-            # Weekly content rebuild: date tag on current semver
-            TAGS="${IMAGE}:latest"
-            TAGS="${TAGS},${IMAGE}:${WEEKLY_TAG}"
           fi
 
           echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
@@ -156,16 +152,14 @@ jobs:
           IS_WEEKLY="${{ steps.tag.outputs.IS_WEEKLY }}"
           WEEKLY_TAG="${{ steps.tag.outputs.WEEKLY_TAG }}"
 
-          # Always sign the latest tag
-          cosign sign -y $REGISTRY:latest
+          # Always sign latest and date-stamped tags
+          cosign sign -y "$REGISTRY:latest"
+          cosign sign -y "$REGISTRY:${WEEKLY_TAG}"
 
           if [[ "${IS_WEEKLY}" == "false" ]]; then
-            # Tag-push: sign semver tags
+            # Tag-push: also sign semver tags
             cosign sign -y "$REGISTRY:v${VERSION}"
             cosign sign -y "$REGISTRY:${VERSION}"
-          else
-            # Weekly content rebuild: sign date tag
-            cosign sign -y "$REGISTRY:${WEEKLY_TAG}"
           fi
 
       - name: Trigger infra image update
@@ -174,7 +168,7 @@ jobs:
         env:
           INFRA_REPO: stacklok/infra
           IMAGE_NAME: ghcr.io/${{ steps.repo_owner.outputs.OWNER }}/toolhive-doc-mcp
-          IMAGE_TAG: ${{ steps.tag.outputs.IS_WEEKLY == 'true' && steps.tag.outputs.WEEKLY_TAG || github.ref_name }}
+          IMAGE_TAG: ${{ steps.tag.outputs.WEEKLY_TAG }}
           GH_TOKEN: ${{ secrets.INFRA_DISPATCH_TOKEN }}
         run: |
           gh api repos/$INFRA_REPO/dispatches \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
       weekly_tag: ${{ steps.version.outputs.WEEKLY_TAG }}
-      is_new_version: ${{ steps.version.outputs.IS_NEW_VERSION }}
       is_weekly: ${{ steps.version.outputs.IS_WEEKLY }}
     steps:
       - name: Checkout code
@@ -31,36 +30,16 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
             echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
             echo "WEEKLY_TAG=" >> $GITHUB_OUTPUT
-            echo "IS_NEW_VERSION=false" >> $GITHUB_OUTPUT
             echo "IS_WEEKLY=false" >> $GITHUB_OUTPUT
           else
-            # Schedule or workflow_dispatch event
+            # Schedule or workflow_dispatch: content rebuild on latest semver
             LATEST_TAG=$(git tag -l 'v*' | grep -v '-' | sort -V | tail -n 1)
             echo "Latest base version tag: ${LATEST_TAG}"
-
-            COMMITS_SINCE=$(git rev-list "${LATEST_TAG}..HEAD" --count)
-            echo "Commits since ${LATEST_TAG}: ${COMMITS_SINCE}"
-
-            # Strip the 'v' prefix to get the version number
-            CURRENT_VERSION="${LATEST_TAG#v}"
-
-            if [[ "${COMMITS_SINCE}" -gt 0 ]]; then
-              # Bump patch version
-              MAJOR=$(echo "${CURRENT_VERSION}" | cut -d. -f1)
-              MINOR=$(echo "${CURRENT_VERSION}" | cut -d. -f2)
-              PATCH=$(echo "${CURRENT_VERSION}" | cut -d. -f3)
-              NEW_PATCH=$((PATCH + 1))
-              VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
-              IS_NEW_VERSION="true"
-            else
-              VERSION="${CURRENT_VERSION}"
-              IS_NEW_VERSION="false"
-            fi
+            VERSION="${LATEST_TAG#v}"
 
             WEEKLY_TAG="v${VERSION}-$(date -u +%Y%m%d)"
             echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
             echo "WEEKLY_TAG=${WEEKLY_TAG}" >> $GITHUB_OUTPUT
-            echo "IS_NEW_VERSION=${IS_NEW_VERSION}" >> $GITHUB_OUTPUT
             echo "IS_WEEKLY=true" >> $GITHUB_OUTPUT
           fi
 
@@ -109,7 +88,6 @@ jobs:
         run: |
           echo "VERSION=${{ needs.determine_version.outputs.version }}" >> $GITHUB_OUTPUT
           echo "WEEKLY_TAG=${{ needs.determine_version.outputs.weekly_tag }}" >> $GITHUB_OUTPUT
-          echo "IS_NEW_VERSION=${{ needs.determine_version.outputs.is_new_version }}" >> $GITHUB_OUTPUT
           echo "IS_WEEKLY=${{ needs.determine_version.outputs.is_weekly }}" >> $GITHUB_OUTPUT
 
       - name: Set repository owner lowercase
@@ -122,22 +100,15 @@ jobs:
           IMAGE="ghcr.io/${{ steps.repo_owner.outputs.OWNER }}/toolhive-doc-mcp"
           VERSION="${{ steps.tag.outputs.VERSION }}"
           IS_WEEKLY="${{ steps.tag.outputs.IS_WEEKLY }}"
-          IS_NEW_VERSION="${{ steps.tag.outputs.IS_NEW_VERSION }}"
           WEEKLY_TAG="${{ steps.tag.outputs.WEEKLY_TAG }}"
 
           if [[ "${IS_WEEKLY}" == "false" ]]; then
-            # Tag-push: latest, v0.0.10, 0.0.10
+            # Tag-push: new semver release
             TAGS="${IMAGE}:latest"
-            TAGS="${TAGS},${IMAGE}:v${VERSION}"
-            TAGS="${TAGS},${IMAGE}:${VERSION}"
-          elif [[ "${IS_NEW_VERSION}" == "true" ]]; then
-            # Weekly with version bump: latest, v0.0.10-20260224, v0.0.10, 0.0.10
-            TAGS="${IMAGE}:latest"
-            TAGS="${TAGS},${IMAGE}:${WEEKLY_TAG}"
             TAGS="${TAGS},${IMAGE}:v${VERSION}"
             TAGS="${TAGS},${IMAGE}:${VERSION}"
           else
-            # Weekly with no new commits: latest, v0.0.9-20260224
+            # Weekly content rebuild: date tag on current semver
             TAGS="${IMAGE}:latest"
             TAGS="${TAGS},${IMAGE}:${WEEKLY_TAG}"
           fi
@@ -174,12 +145,6 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      - name: Create git tag for version bump
-        if: steps.tag.outputs.IS_NEW_VERSION == 'true'
-        run: |
-          git tag "v${{ steps.tag.outputs.VERSION }}"
-          git push origin "v${{ steps.tag.outputs.VERSION }}"
-
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
@@ -189,23 +154,17 @@ jobs:
         run: |
           VERSION="${{ steps.tag.outputs.VERSION }}"
           IS_WEEKLY="${{ steps.tag.outputs.IS_WEEKLY }}"
-          IS_NEW_VERSION="${{ steps.tag.outputs.IS_NEW_VERSION }}"
           WEEKLY_TAG="${{ steps.tag.outputs.WEEKLY_TAG }}"
 
           # Always sign the latest tag
           cosign sign -y $REGISTRY:latest
 
           if [[ "${IS_WEEKLY}" == "false" ]]; then
-            # Tag-push: sign v0.0.10 and 0.0.10
-            cosign sign -y "$REGISTRY:v${VERSION}"
-            cosign sign -y "$REGISTRY:${VERSION}"
-          elif [[ "${IS_NEW_VERSION}" == "true" ]]; then
-            # Weekly with version bump: sign timestamped, v0.0.10, and 0.0.10
-            cosign sign -y "$REGISTRY:${WEEKLY_TAG}"
+            # Tag-push: sign semver tags
             cosign sign -y "$REGISTRY:v${VERSION}"
             cosign sign -y "$REGISTRY:${VERSION}"
           else
-            # Weekly with no new commits: sign timestamped tag
+            # Weekly content rebuild: sign date tag
             cosign sign -y "$REGISTRY:${WEEKLY_TAG}"
           fi
 


### PR DESCRIPTION
## Summary
- Remove automatic patch version bumping from scheduled/dispatch workflow runs
- Every build now publishes a date-stamped tag (e.g. `v0.0.13-20260415`) regardless of trigger, so downstream Renovate matchers can consistently track image updates
- Tag pushes produce the full set: `latest`, `v0.0.13-20260415`, `v0.0.13`, `0.0.13`
- Weekly/dispatch runs produce only: `latest`, `v0.0.13-20260421`
- Infra dispatch always sends the date-stamped tag
- Fixes a double-trigger bug where the weekly run's `git push` of a new `v*` tag would re-fire the entire workflow via the `push: tags` trigger

## Test plan
- [ ] Verify `workflow_dispatch` run produces only `latest` + date tag (no semver bump)
- [ ] Verify manual `v*` tag push produces semver tags AND date tag
- [ ] Confirm no double-trigger on version tag push
- [ ] Confirm infra dispatch receives the date-stamped tag in both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)