### PR TITLE
chore(renovate): group updates and move to weekly schedule

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1.0
+        uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1.0
+        uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,66 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:weekly"
   ],
   "recreateWhen": "never",
   "dependencyDashboard": true,
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 9am on monday"
+    ]
   },
   "packageRules": [
     {
       "matchManagers": ["pep621"],
       "rangeStrategy": "bump"
+    },
+    {
+      "groupName": "github actions (actions/*)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/**"]
+    },
+    {
+      "groupName": "github actions (docker/*)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["docker/**"]
+    },
+    {
+      "groupName": "github actions (other)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!actions/**", "!docker/**"]
+    },
+    {
+      "groupName": "opentelemetry",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["opentelemetry-**"]
+    },
+    {
+      "groupName": "pydantic",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["pydantic", "pydantic-settings"]
+    },
+    {
+      "groupName": "mcp",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["mcp{/,}**", "fastmcp"]
+    },
+    {
+      "groupName": "dev dependencies",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dev"]
+    },
+    {
+      "groupName": "security dependencies",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["security"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "schedule:weekly"
+    "config:recommended"
   ],
   "recreateWhen": "never",
   "dependencyDashboard": true,
@@ -50,7 +49,7 @@
     {
       "groupName": "mcp",
       "matchManagers": ["pep621"],
-      "matchPackageNames": ["mcp{/,}**", "fastmcp"]
+      "matchPackageNames": ["mcp", "fastmcp"]
     },
     {
       "groupName": "dev dependencies",


### PR DESCRIPTION
## Summary

Cuts Renovate PR noise by grouping updates along logical boundaries and moving to a weekly schedule.

**Groups**
- GitHub Actions: split into `actions/*`, `docker/*`, and a catch-all "other" bucket
- `opentelemetry-*` — the 5 OTel packages that version together
- `pydantic` + `pydantic-settings`
- `mcp` + `fastmcp`
- `dev` and `security` dependency-groups each bundled into a single PR

Main project dependencies (httpx, lxml, tiktoken, etc.) remain ungrouped so any breaking bumps stay isolated and easy to revert.

**Schedule**
- Weekly, `before 9am on monday` — applies to both package updates and `lockFileMaintenance`
- `prConcurrentLimit: 5` to cap outstanding Renovate PRs

Branch name `renovate/reconfigure` so Renovate validates the new config.

## Test plan
- [ ] Renovate config validation passes on this PR
- [ ] After merge, confirm next Monday run produces grouped PRs as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)