### PR TITLE
fix: disable background refresh by default

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -68,6 +68,6 @@ github:
 
 # Background refresh configuration
 refresh:
-  enabled: true  # Enable/disable background refresh
+  enabled: false  # Enable/disable background refresh
   interval_hours: 24  # Refresh every 24 hours
   max_concurrent_jobs: 1  # Prevent overlapping refreshes

--- a/sources.yaml.example
+++ b/sources.yaml.example
@@ -53,6 +53,6 @@ github:
 
 # Background refresh configuration
 refresh:
-  enabled: true  # Enable/disable background refresh
+  enabled: false  # Enable/disable background refresh
   interval_hours: 24  # Refresh every 24 hours
   max_concurrent_jobs: 1  # Prevent overlapping refreshes


### PR DESCRIPTION
## Summary
- Flip `refresh.enabled` from `true` to `false` in `sources.yaml` and `sources.yaml.example`.
- Public users pulling the GHCR image were getting a silent background refresh every 24h, re-crawling docs.stacklok.com and hitting the GitHub API unauthenticated.
- Stacklok-deployed pods already override this via `REFRESH_ENABLED=false` in the pod spec, so production is unaffected. Anyone who wants the old behavior can set `REFRESH_ENABLED=true` or edit their `sources.yaml`.

## Test plan
- [ ] Confirm `ruff check src/` passes
- [ ] Confirm existing refresh integration tests still pass (they set `refresh.enabled` explicitly in fixtures, so they don't depend on the YAML default)
- [ ] After release, pull the new image locally and confirm logs show "Background refresh is disabled" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)